### PR TITLE
Feature: Adds check for partition style on Invoke-IcingaCheckClusterSharedVolume

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -10,6 +10,10 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-cluster/milestone/2?closed=1)
 
+### Enhancements
+
+* [#28](https://github.com/Icinga/icinga-powershell-cluster/issues/28) Adds partition style monitoring to `Invoke-IcingaCheckClusterSharedVolume` and reports critical, if the style is `RAW`
+
 ### Bugfixes
 
 * [#36](https://github.com/Icinga/icinga-powershell-cluster/issues/36) Fixes `Invoke-IcingaCheckClusterSharedVolume` which does not support `%` unit for space

--- a/plugins/Invoke-IcingaCheckClusterSharedVolume.psm1
+++ b/plugins/Invoke-IcingaCheckClusterSharedVolume.psm1
@@ -169,6 +169,15 @@ function Invoke-IcingaCheckClusterSharedVolume()
                         'NoAccess'
                     )
                 );
+
+                $VolumeCheckPackage.AddCheck(
+                    (
+                        New-IcingaCheck `
+                            -Name ([string]::Format('{0} Partition Style', $volume)) `
+                            -Value $VolumeObj.SharedVolumeInfo.Partition.PartitionStyle `
+                            -NoPerfData
+                    ).CritIfLike('RAW')
+                );
             }
 
             # Checks for Cluster SharedVolume members, that are owned by the individual ClusterNodes


### PR DESCRIPTION
Adds a check for the partition style on `Invoke-IcingaCheckClusterSharedVolume` by checking the partition style and reports critical, if the result is `RAW`

Fixes #28