### PR TITLE
Fix: CSVD not being public available

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -6,6 +6,14 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-cluster/milestones?state=closed).
 
+## 1.1.1 (2022-05-13)
+
+[Issue and PRs](https://github.com/Icinga/icinga-powershell-cluster/milestone/3?closed=1)
+
+### Bugfixes
+
+* [#40](https://github.com/Icinga/icinga-powershell-cluster/issues/40) Fixes `Get-IcingaClusterSharedVolumeData` which was not available as public function and caused Hyper-V plugins to fail, because they rely on this function inside a cluster
+
 ## 1.1.0 (2022-05-03)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-cluster/milestone/2?closed=1)

--- a/icinga-powershell-cluster.psd1
+++ b/icinga-powershell-cluster.psd1
@@ -17,7 +17,8 @@
         'Import-IcingaPowerShellComponentCluster',
         'Invoke-IcingaCheckClusterHealth',
         'Invoke-IcingaCheckClusterNetwork',
-        'Invoke-IcingaCheckClusterSharedVolume'
+        'Invoke-IcingaCheckClusterSharedVolume',
+        'Get-IcingaClusterSharedVolumeData'
     )
     CmdletsToExport     = @(
     )

--- a/provider/sharedVolume/Get-IcingaClusterSharedVolumeData.psm1
+++ b/provider/sharedVolume/Get-IcingaClusterSharedVolumeData.psm1
@@ -16,7 +16,7 @@
 .LINK
     https://github.com/Icinga/icinga-powershell-cluster
 #>
-function Get-IcingaClusterSharedVolumeData()
+function Global:Get-IcingaClusterSharedVolumeData()
 {
     param (
         [array]$IncludeVolumes = @(),


### PR DESCRIPTION
Fixes `Get-IcingaClusterSharedVolumeData` which was not available as public function and caused Hyper-V plugins to fail, because they rely on this function inside a cluster

Fixes #40