### PR TITLE
Fix: Missing check for CSV check on state info

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -10,6 +10,10 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-cluster/milestone/4?closed=1)
 
+### Bugfixes
+
+* [#42](https://github.com/Icinga/icinga-powershell-cluster/pull/42) Fixes missing check of state info for Cluster Shared Volume plugin, if the state info is not `Direct`
+
 ### Enhancements
 
 * [#43](https://github.com/Icinga/icinga-powershell-cluster/pull/43) Updates configuration and dependencies for Icinga for Windows v1.10.0

--- a/plugins/Invoke-IcingaCheckClusterSharedVolume.psm1
+++ b/plugins/Invoke-IcingaCheckClusterSharedVolume.psm1
@@ -203,16 +203,18 @@ function Invoke-IcingaCheckClusterSharedVolume()
                     )
                 );
 
-                $NodeCheckPackage.AddCheck(
-                    (
-                        New-IcingaCheck `
-                            -Name ([string]::Format('{0} StateInfo', $volume)) `
-                            -Value $OwnerNode.StateInfo `
-                            -NoPerfData
-                    ).CritIfMatch(
-                        'Unavailable'
-                    )
-                );
+                $StateInfoCheck = New-IcingaCheck `
+                    -Name ([string]::Format('{0} StateInfo', $volume)) `
+                    -Value $OwnerNode.StateInfo `
+                    -NoPerfData;
+
+                $StateInfoCheck.CritIfMatch('Unavailable') | Out-Null;
+
+                if ($OwnerNode.BlockRedirectedIOReason -eq 'NoDiskConnectivity') {
+                    $StateInfoCheck.WarnIfNotMatch('Direct') | Out-Null;
+                }
+
+                $NodeCheckPackage.AddCheck($StateInfoCheck);
 
                 $NodeCheckPackage.AddCheck(
                     (


### PR DESCRIPTION
Fixes missing check of state info for Cluster Shared Volume plugin, if the state info is not `Direct`

Fixes #42