### PR TITLE
Update Get-IcingaClusterSharedVolumeData.psm1

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -6,6 +6,12 @@ documentation before upgrading to a new release.
 
 Released closed milestones can be found on [GitHub](https://github.com/Icinga/icinga-powershell-cluster/milestones?state=closed).
 
+## 1.3.0 (2023-08-01)
+
+[Issue and PRs](https://github.com/Icinga/icinga-powershell-cluster/milestone/5?closed=1)
+
+* [#50](https://github.com/Icinga/icinga-powershell-cluster/pull/50) Fixes unwanted dependency between cluster shared volumes and shared disks
+
 ## 1.2.0 (2022-08-30)
 
 [Issue and PRs](https://github.com/Icinga/icinga-powershell-cluster/milestone/4?closed=1)

--- a/provider/sharedVolume/Get-IcingaClusterSharedVolumeData.psm1
+++ b/provider/sharedVolume/Get-IcingaClusterSharedVolumeData.psm1
@@ -71,7 +71,7 @@ function Global:Get-IcingaClusterSharedVolumeData()
         'Resources' = @{ };
     };
 
-    if ($null -eq $GetClusterResource -or $null -eq $GetSharedVolume) {
+    if ($null -eq $GetClusterResource -and $null -eq $GetSharedVolume) {
         return @{ };
     }
 
@@ -174,18 +174,17 @@ function Global:Get-IcingaClusterSharedVolumeData()
             $details.SharedVolumeInfo.Add('Unknown', 'Unknown');
         }
 
-        foreach ($resource in $GetClusterResource.Keys) {
-            $ClusterResource = $GetClusterResource[$resource];
-            if (($ClusterResource.Type -ne 'Physical Disk' -and $ClusterResource.Type -ne 'Storage QoS Policy Manager') -or ($SharedVolumes.Contains($resource) -eq $TRUE)) {
-                continue;
-            }
-
-            $SharedVolumes += $resource;
-            $ClusterDetails.Resources.Add($resource, $ClusterResource);
-        }
-
         $ClusterDetails.Add($volume.Name, $details);
     }
 
+    foreach ($resource in $GetClusterResource.Keys) {
+        $ClusterResource = $GetClusterResource[$resource];
+        if (($ClusterResource.Type -ne 'Physical Disk' -and $ClusterResource.Type -ne 'Storage QoS Policy Manager') -or ($SharedVolumes.Contains($resource) -eq $TRUE)) {
+            continue;
+        }
+
+        $SharedVolumes += $resource;
+        $ClusterDetails.Resources.Add($resource, $ClusterResource);
+    }
     return $ClusterDetails;
 }


### PR DESCRIPTION
This pull request resolves the dependency between clustered shared volume and shared disk in the "Invoke-IcingaCheckClusterSharedVolume" check.

The following constellations were then tested with the adjustment:

Clustered Shared Volumes and Shared Disk
Both are properly monitored

Clustered shared volumes only
Only the clustered shared volumes are monitored.

Shared disk only
Only the shared disks contained in the cluster are monitored.

Neither Cluster Shared Volumes nor Shared Disk
The check has the status "unknown" in Icinga because neither cluster shared volumes nor shared disks were found.

This pull request corresponds to support case #784384.